### PR TITLE
feat: update season logo upload to use S3 and CloudFront for storage …

### DIFF
--- a/services/season_service.go
+++ b/services/season_service.go
@@ -2,10 +2,12 @@ package services
 
 import (
 	"errors"
+	"fmt"
+	"go-gin-starter/config"
 	"go-gin-starter/dto"
 	"go-gin-starter/models"
-	"go-gin-starter/repositories"
 	"go-gin-starter/pkg/constants"
+	"go-gin-starter/repositories"
 
 	"github.com/google/uuid"
 )
@@ -18,7 +20,6 @@ func CreateSeasonService(input *dto.CreateSeasonInput) (*dto.SeasonResponse, err
 		Gender:     input.Gender,
 		SeasonType: input.SeasonType,
 		SeasonYear: input.SeasonYear,
-		Round:      input.Round,
 		StartDate:  input.StartDate,
 		EndDate:    input.EndDate,
 		Logo:       "defaults/default-season-logo.png",
@@ -37,7 +38,6 @@ func CreateSeasonService(input *dto.CreateSeasonInput) (*dto.SeasonResponse, err
 		SeasonYear: season.SeasonYear,
 		StartDate:  season.StartDate,
 		EndDate:    season.EndDate,
-		Round:      season.Round,
 		LogoURL:    "/uploads/logos/" + season.Logo,
 		CreatedAt:  season.CreatedAt,
 		UpdatedAt:  season.UpdatedAt,
@@ -63,10 +63,11 @@ func GetAllSeasonsService() ([]dto.SeasonResponse, error) {
 			SeasonYear: season.SeasonYear,
 			StartDate:  season.StartDate,
 			EndDate:    season.EndDate,
-			Round:      season.Round,
-			LogoURL:    "/uploads/logos/" + season.Logo,
-			CreatedAt:  season.CreatedAt,
-			UpdatedAt:  season.UpdatedAt,
+			// LogoURL:    "/uploads/logos/" + season.Logo,
+			LogoURL: fmt.Sprintf("https://%s/logos/seasons/%s", config.AssetCloudFrontDomain, season.Logo),
+
+			CreatedAt: season.CreatedAt,
+			UpdatedAt: season.UpdatedAt,
 		})
 	}
 	return responses, nil
@@ -88,10 +89,11 @@ func GetSeasonByIDService(id uuid.UUID) (*dto.SeasonResponse, error) {
 		SeasonYear: season.SeasonYear,
 		StartDate:  season.StartDate,
 		EndDate:    season.EndDate,
-		Round:      season.Round,
-		LogoURL:    "/uploads/logos/" + season.Logo,
-		CreatedAt:  season.CreatedAt,
-		UpdatedAt:  season.UpdatedAt,
+		// LogoURL:    "/uploads/logos/" + season.Logo,
+		LogoURL: fmt.Sprintf("https://%s/logos/seasons/%s", config.AssetCloudFrontDomain, season.Logo),
+
+		CreatedAt: season.CreatedAt,
+		UpdatedAt: season.UpdatedAt,
 	}
 	return &response, nil
 }
@@ -141,10 +143,11 @@ func UpdateSeasonService(id uuid.UUID, input *dto.UpdateSeasonInput) (*dto.Seaso
 		SeasonYear: season.SeasonYear,
 		StartDate:  season.StartDate,
 		EndDate:    season.EndDate,
-		Round:      season.Round,
-		LogoURL:    "/uploads/logos/" + season.Logo,
-		CreatedAt:  season.CreatedAt,
-		UpdatedAt:  season.UpdatedAt,
+		//		LogoURL:    "/uploads/logos/" + season.Logo,
+		LogoURL: fmt.Sprintf("https://%s/logos/seasons/%s", config.AssetCloudFrontDomain, season.Logo),
+
+		CreatedAt: season.CreatedAt,
+		UpdatedAt: season.UpdatedAt,
 	}
 	return &response, nil
 }


### PR DESCRIPTION
This pull request introduces changes to the season logo upload functionality and updates how season logos are stored and retrieved. The changes primarily focus on integrating AWS S3 for logo storage and replacing local file paths with CloudFront URLs. Additionally, the `Round` field has been removed from several season-related service methods.

### Changes to logo upload and storage:

* Modified `UploadSeasonLogo` in `controllers/admin_season_controller.go` to upload season logos to AWS S3 instead of saving them locally. This includes extracting the file content, generating a key, and calling `storage.UploadFileToS3`.
* Updated the `LogoURL` field in multiple service methods (`GetAllSeasonsService`, `GetSeasonByIDService`, `UpdateSeasonService`) to use CloudFront URLs instead of local file paths. [[1]](diffhunk://#diff-3745845d8da45c9fa1bac328598f0b26c42e7ccc49ca7eb4aa11d3eea140f19bL66-R68) [[2]](diffhunk://#diff-3745845d8da45c9fa1bac328598f0b26c42e7ccc49ca7eb4aa11d3eea140f19bL91-R94) [[3]](diffhunk://#diff-3745845d8da45c9fa1bac328598f0b26c42e7ccc49ca7eb4aa11d3eea140f19bL144-R148)

### Code cleanup and refactoring:

* Removed the `Round` field from the `CreateSeasonService`, `GetAllSeasonsService`, `GetSeasonByIDService`, and `UpdateSeasonService` methods, as it is no longer required. [[1]](diffhunk://#diff-3745845d8da45c9fa1bac328598f0b26c42e7ccc49ca7eb4aa11d3eea140f19bL21) [[2]](diffhunk://#diff-3745845d8da45c9fa1bac328598f0b26c42e7ccc49ca7eb4aa11d3eea140f19bL40) [[3]](diffhunk://#diff-3745845d8da45c9fa1bac328598f0b26c42e7ccc49ca7eb4aa11d3eea140f19bL66-R68) [[4]](diffhunk://#diff-3745845d8da45c9fa1bac328598f0b26c42e7ccc49ca7eb4aa11d3eea140f19bL91-R94) [[5]](diffhunk://#diff-3745845d8da45c9fa1bac328598f0b26c42e7ccc49ca7eb4aa11d3eea140f19bL144-R148)
* Adjusted imports in both `admin_season_controller.go` and `season_service.go` to include necessary packages like `storage` and `config`. [[1]](diffhunk://#diff-3d255468dca5520ec15f2e2abd4b159f4f1689834ab9a1aa85adc609415d2ca8L5-R8) [[2]](diffhunk://#diff-3745845d8da45c9fa1bac328598f0b26c42e7ccc49ca7eb4aa11d3eea140f19bR5-R10)…and retrieval